### PR TITLE
Fixed HY093 error

### DIFF
--- a/wp2hashover.php
+++ b/wp2hashover.php
@@ -190,17 +190,18 @@ if($reqPosts->rowCount() > 0) {
 	$reqPostNameDoublon->execute();
 	echo 'Add '.$row['post_name'].' page : ';
 	// If not exist
+	$datapi=array();
 	if($reqPostNameDoublon->rowCount() == 0) {
-	    $data['domain']=$hashover_domain;
-	    $data['thread']=$row['post_name'];
-	    $data['url']=$wp_siteurl.$row['post_name'].'/';
-	    $data['title']=$row['post_title'];
+	    $datapi['domain']=$hashover_domain;
+	    $datapi['thread']=$row['post_name'];
+	    $datapi['url']=$wp_siteurl.$row['post_name'].'/';
+	    $datapi['title']=$row['post_title'];
 	    $insertcmd = $hashoverDbConnect->prepare("INSERT INTO `page-info` (domain, thread, url, title) 
 						    VALUES (:domain, :thread, :url, :title)");
 						    
-	    $insertcmd->execute($data);
+	    $insertcmd->execute($datapi);
 	    //~ var_dump($insertcmd->debugDumpParams());
-	    //~ var_dump($data);
+	    //~ var_dump($datapi);
 	    echo 'Ok';
 	} else {
 	    echo '**Already registered**';


### PR DESCRIPTION
When inserting data into `page-info` table it was showing:

```
Warning: PDOStatement::execute(): SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens in /path/to/wp2hashover/wp2hashover.php on line 201
```

[It turns out](https://stackoverflow.com/a/19779268) there were extra values in the `$data` from previous use that was raising an `HY093` error. This commit fixes it by using a new variable name.